### PR TITLE
Feat: add endpoint for get all moveis

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -182,7 +182,7 @@ linters:
     - nilnil
     - nlreturn
     - noctx
-    - nolintlint
+    # - nolintlint
     #- nonamedreturns
     - nosprintfhostport
     - paralleltest

--- a/backend/app/core/movie.go
+++ b/backend/app/core/movie.go
@@ -40,7 +40,7 @@ type QueryParams struct {
 	Export string            `json:"export"`
 }
 
-//  Set the default values to the Limit and Offset fields.
+// Set the default values to the Limit and Offset fields.
 func (qp *QueryParams) SetDefaultValues() {
 	if qp.Limit == "" {
 		qp.Limit = "20"
@@ -56,19 +56,13 @@ func (qp QueryParams) Validate() error {
 	var (
 		minOffset          = 0
 		maxOffset          = 1000
-		minLimit           = 1
-		maxLimit           = 1000
+		allowedLimitVal    = []string{"20", "50", "100"}
 		AllowedFilterKey   = []string{"genre", "rate"}
 		AllowedSortKey     = []string{"rate", "release_date", "duration"}
 		AllowedExportValue = []string{"csv", ""}
 	)
 
-	limit, err := strconv.Atoi(qp.Limit)
-	if err != nil {
-		return fmt.Errorf("limit has to be an integer: %w", err)
-	}
-
-	if limit < minLimit || limit > maxLimit {
+	if notInSlice(qp.Limit, allowedLimitVal) {
 		return ErrUnallowedLimit
 	}
 

--- a/backend/app/core/movie.go
+++ b/backend/app/core/movie.go
@@ -34,11 +34,16 @@ var (
 // QueryParams represent request query params
 // that will be used on transport and repository level.
 type QueryParams struct {
-	Limit  string            `json:"limit"`
-	Offset string            `json:"offset"`
-	Filter map[string]string `json:"filter"`
-	Sort   map[string]string `json:"sort"`
-	Export string            `json:"export"`
+	Limit  string              `json:"limit"`
+	Offset string              `json:"offset"`
+	Filter []QuerySliceElement `json:"filter"`
+	Sort   []QuerySliceElement `json:"sort"`
+	Export string              `json:"export"`
+}
+
+type QuerySliceElement struct {
+	Key string
+	Val string
 }
 
 // Set the default values to the Limit and Offset fields.
@@ -62,7 +67,7 @@ func (qp QueryParams) Validate() error {
 		allowedLimitVal    = []string{"20", "50", "100"}
 		allowedFilterKey   = []string{"genre", "rate"}
 		allowedSortKey     = []string{"rate", "release_date", "duration"}
-		allowedSortValue   = []string{"asc", "dsc"}
+		allowedSortValue   = []string{"asc", "desc"}
 		allowedExportValue = []string{"csv", ""}
 	)
 
@@ -79,13 +84,13 @@ func (qp QueryParams) Validate() error {
 		return fmt.Errorf("offset should be in range from %v to %v: %w", minOffset, maxOffset, ErrUnallowedOffset)
 	}
 
-	for key, val := range qp.Filter {
-		if notInSlice(key, allowedFilterKey) {
+	for _, elem := range qp.Filter {
+		if notInSlice(elem.Key, allowedFilterKey) {
 			return ErrUnallowedFilterKey
 		}
 
-		if key == "rate" {
-			i, err := strconv.Atoi(val)
+		if elem.Key == "rate" {
+			i, err := strconv.Atoi(elem.Val)
 			if err != nil {
 				return fmt.Errorf("the value shlould be an integer: %w", err)
 			}
@@ -96,15 +101,14 @@ func (qp QueryParams) Validate() error {
 		}
 	}
 
-	for key, val := range qp.Sort {
-		if notInSlice(key, allowedSortKey) {
-			return fmt.Errorf("key %v is bad: %w", key, ErrUnallowedSort)
+	for _, elem := range qp.Sort {
+		if notInSlice(elem.Key, allowedSortKey) {
+			return fmt.Errorf("key %v is bad: %w", elem.Key, ErrUnallowedSort)
 		}
 
-		if notInSlice(val, allowedSortValue) {
+		if notInSlice(elem.Val, allowedSortValue) {
 			return fmt.Errorf("the sort value: %w", ErrUnallowedSort)
 		}
-
 	}
 
 	if notInSlice(qp.Export, allowedExportValue) {

--- a/backend/app/repositorie/pg/movie.go
+++ b/backend/app/repositorie/pg/movie.go
@@ -52,10 +52,6 @@ func (d MovieDB) InsertMovie(movie core.Movie) error {
 	return nil
 }
 
-func (d MovieDB) SelectAllMovies() error {
-	return nil
-}
-
 // Select and return the movie entities via movie ID.
 func (d MovieDB) SelectMovieByID(movieID string) (core.Movie, error) {
 	query := `SELECT id, director_id, title, ganre, rate, release_date, duration, created, modified
@@ -71,4 +67,21 @@ func (d MovieDB) SelectMovieByID(movieID string) (core.Movie, error) {
 	}
 
 	return movie, nil
+}
+
+func (d MovieDB) SelectAllMovies(param string) ([]core.Movie, error) {
+	query := `SELECT id, director_id, title, genre, rate, release_date, duration, created, modified FROM public.movie `
+
+	query = query + param
+
+	var movieList []core.Movie
+	if err := d.db.Select(&movieList, query); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, core.ErrMovieNotFound
+		}
+
+		return nil, fmt.Errorf("an error occurs while getting the movie list: %w", err)
+	}
+
+	return movieList, nil
 }

--- a/backend/app/repositorie/pg/movie.go
+++ b/backend/app/repositorie/pg/movie.go
@@ -129,43 +129,43 @@ func (d MovieDB) SelectMoviesCSV(qp core.QueryParams) ([]core.MovieCSV, error) {
 	return csvList, nil
 }
 
-func (d MovieDB) makeConditionQuery(qp core.QueryParams) string {
+func (d MovieDB) makeConditionQuery(queryParameter core.QueryParams) string {
 	var queryCondition string
 
-	if len(qp.Filter) > 0 {
+	if len(queryParameter.Filter) > 0 {
 		where := "WHERE "
 
-		for i := 0; i < len(qp.Filter); i++ {
-			if qp.Filter[i].Val != "" {
-				if _, err := strconv.Atoi(qp.Filter[i].Val); err == nil {
-					where = where + qp.Filter[i].Key + ">=" + qp.Filter[i].Val + " AND "
+		for i := 0; i < len(queryParameter.Filter); i++ {
+			if queryParameter.Filter[i].Val != "" {
+				if _, err := strconv.Atoi(queryParameter.Filter[i].Val); err == nil {
+					where = where + queryParameter.Filter[i].Key + ">=" + queryParameter.Filter[i].Val + " AND "
 				} else {
-					where = where + qp.Filter[i].Key + "='" + qp.Filter[i].Val + "' AND "
+					where = where + queryParameter.Filter[i].Key + "='" + queryParameter.Filter[i].Val + "' AND "
 				}
 			}
 		}
 
 		where = strings.TrimSuffix(where, "AND ")
 
-		queryCondition = queryCondition + where
+		queryCondition += where
 	}
 
-	if len(qp.Sort) > 0 {
+	if len(queryParameter.Sort) > 0 {
 		order := "ORDER BY "
 
-		for i := 0; i < len(qp.Sort); i++ {
-			if qp.Sort[i].Val != "" {
-				order = order + qp.Sort[i].Key + " " + qp.Sort[i].Val + ", "
+		for i := 0; i < len(queryParameter.Sort); i++ {
+			if queryParameter.Sort[i].Val != "" {
+				order = order + queryParameter.Sort[i].Key + " " + queryParameter.Sort[i].Val + ", "
 			}
 		}
 
 		order = strings.TrimSuffix(order, ", ")
 
-		queryCondition = queryCondition + order
+		queryCondition += order
 	}
 
-	queryCondition = queryCondition + " LIMIT " + qp.Limit
-	queryCondition = queryCondition + " OFFSET " + qp.Offset
+	queryCondition = queryCondition + " LIMIT " + queryParameter.Limit
+	queryCondition = queryCondition + " OFFSET " + queryParameter.Offset
 
 	return queryCondition
 }

--- a/backend/app/service/contract.go
+++ b/backend/app/service/contract.go
@@ -24,6 +24,7 @@ type DirectorStorage interface {
 
 type MovieStorage interface {
 	InsertMovie(movie core.Movie) error
-	SelectAllMovies(ord string) ([]core.Movie, error)
+	SelectAllMovies(core.QueryParams) ([]core.Movie, error)
+	SelectMoviesCSV(qp core.QueryParams) ([]core.MovieCSV, error)
 	SelectMovieByID(movieID string) (core.Movie, error)
 }

--- a/backend/app/service/contract.go
+++ b/backend/app/service/contract.go
@@ -24,6 +24,6 @@ type DirectorStorage interface {
 
 type MovieStorage interface {
 	InsertMovie(movie core.Movie) error
-	SelectAllMovies() error
+	SelectAllMovies(ord string) ([]core.Movie, error)
 	SelectMovieByID(movieID string) (core.Movie, error)
 }

--- a/backend/app/service/contract_mock_test.go
+++ b/backend/app/service/contract_mock_test.go
@@ -242,18 +242,18 @@ func (mr *MockMovieStorageMockRecorder) InsertMovie(movie interface{}) *gomock.C
 }
 
 // SelectAllMovies mocks base method.
-func (m *MockMovieStorage) SelectAllMovies(ord string) ([]core.Movie, error) {
+func (m *MockMovieStorage) SelectAllMovies(arg0 core.QueryParams) ([]core.Movie, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SelectAllMovies", ord)
+	ret := m.ctrl.Call(m, "SelectAllMovies", arg0)
 	ret0, _ := ret[0].([]core.Movie)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SelectAllMovies indicates an expected call of SelectAllMovies.
-func (mr *MockMovieStorageMockRecorder) SelectAllMovies(ord interface{}) *gomock.Call {
+func (mr *MockMovieStorageMockRecorder) SelectAllMovies(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectAllMovies", reflect.TypeOf((*MockMovieStorage)(nil).SelectAllMovies), ord)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectAllMovies", reflect.TypeOf((*MockMovieStorage)(nil).SelectAllMovies), arg0)
 }
 
 // SelectMovieByID mocks base method.
@@ -269,4 +269,19 @@ func (m *MockMovieStorage) SelectMovieByID(movieID string) (core.Movie, error) {
 func (mr *MockMovieStorageMockRecorder) SelectMovieByID(movieID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectMovieByID", reflect.TypeOf((*MockMovieStorage)(nil).SelectMovieByID), movieID)
+}
+
+// SelectMoviesCSV mocks base method.
+func (m *MockMovieStorage) SelectMoviesCSV(qp core.QueryParams) ([]core.MovieCSV, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelectMoviesCSV", qp)
+	ret0, _ := ret[0].([]core.MovieCSV)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SelectMoviesCSV indicates an expected call of SelectMoviesCSV.
+func (mr *MockMovieStorageMockRecorder) SelectMoviesCSV(qp interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectMoviesCSV", reflect.TypeOf((*MockMovieStorage)(nil).SelectMoviesCSV), qp)
 }

--- a/backend/app/service/contract_mock_test.go
+++ b/backend/app/service/contract_mock_test.go
@@ -242,17 +242,18 @@ func (mr *MockMovieStorageMockRecorder) InsertMovie(movie interface{}) *gomock.C
 }
 
 // SelectAllMovies mocks base method.
-func (m *MockMovieStorage) SelectAllMovies() error {
+func (m *MockMovieStorage) SelectAllMovies(ord string) ([]core.Movie, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SelectAllMovies")
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "SelectAllMovies", ord)
+	ret0, _ := ret[0].([]core.Movie)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // SelectAllMovies indicates an expected call of SelectAllMovies.
-func (mr *MockMovieStorageMockRecorder) SelectAllMovies() *gomock.Call {
+func (mr *MockMovieStorageMockRecorder) SelectAllMovies(ord interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectAllMovies", reflect.TypeOf((*MockMovieStorage)(nil).SelectAllMovies))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectAllMovies", reflect.TypeOf((*MockMovieStorage)(nil).SelectAllMovies), ord)
 }
 
 // SelectMovieByID mocks base method.

--- a/backend/app/service/movie.go
+++ b/backend/app/service/movie.go
@@ -39,46 +39,46 @@ func (m MovieService) Get(movieID string) (core.Movie, error) {
 // The general meaning of this service is to generate sql query parameter
 // and get the movie list from the database using that query parameter.
 func (m MovieService) GetList(qp core.QueryParams) ([]core.Movie, error) {
-	var queryParams string
+	var queryCondition string
 
 	if len(qp.Filter) > 0 {
 		where := "WHERE "
 
-		for field, value := range qp.Filter {
-			if value != "" {
-				if _, err := strconv.Atoi(value); err == nil {
-					where = where + field + ">" + value + " AND "
+		for i := 0; i < len(qp.Filter); i++ {
+			if qp.Filter[i].Val != "" {
+				if _, err := strconv.Atoi(qp.Filter[i].Val); err == nil {
+					where = where + qp.Filter[i].Key + ">=" + qp.Filter[i].Val + " AND "
 				} else {
-					where = where + field + "='" + value + "' AND "
+					where = where + qp.Filter[i].Key + "='" + qp.Filter[i].Val + "' AND "
 				}
 			}
 		}
 
 		where = strings.TrimSuffix(where, "AND ")
 
-		queryParams = queryParams + where
+		queryCondition = queryCondition + where
 	}
 
 	if len(qp.Sort) > 0 {
 		order := "ORDER BY "
 
-		for field, value := range qp.Sort {
-			if value != "" {
-				order = order + field + " " + value + ", "
+		for i := 0; i < len(qp.Sort); i++ {
+			if qp.Sort[i].Val != "" {
+				order = order + qp.Sort[i].Key + " " + qp.Sort[i].Val + ", "
 			}
 		}
 
 		order = strings.TrimSuffix(order, ", ")
 
-		queryParams = queryParams + order
+		queryCondition = queryCondition + order
 	}
 
-	queryParams = queryParams + " LIMIT " + qp.Limit
-	queryParams = queryParams + " OFFSET " + qp.Offset
+	queryCondition = queryCondition + " LIMIT " + qp.Limit
+	queryCondition = queryCondition + " OFFSET " + qp.Offset
 
-	movieList, err := m.movieStorage.SelectAllMovies(queryParams)
+	movieList, err := m.movieStorage.SelectAllMovies(queryCondition)
 	if err != nil {
-		return nil, fmt.Errorf("service Get got the error: %w", err)
+		return nil, fmt.Errorf("error while selecting movies: %w", err)
 	}
 
 	return movieList, nil

--- a/backend/app/service/movie.go
+++ b/backend/app/service/movie.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/Brigant/PetPorject/backend/app/core"
 )
@@ -32,4 +34,52 @@ func (m MovieService) Get(movieID string) (core.Movie, error) {
 	}
 
 	return movie, nil
+}
+
+// The general meaning of this service is to generate sql query parameter
+// and get the movie list from the database using that query parameter.
+func (m MovieService) GetList(qp core.QueryParams) ([]core.Movie, error) {
+	var queryParams string
+
+	if len(qp.Filter) > 0 {
+		where := "WHERE "
+
+		for field, value := range qp.Filter {
+			if value != "" {
+				if _, err := strconv.Atoi(value); err == nil {
+					where = where + field + ">" + value + " AND "
+				} else {
+					where = where + field + "='" + value + "' AND "
+				}
+			}
+		}
+
+		where = strings.TrimSuffix(where, "AND ")
+
+		queryParams = queryParams + where
+	}
+
+	if len(qp.Sort) > 0 {
+		order := "ORDER BY "
+
+		for field, value := range qp.Sort {
+			if value != "" {
+				order = order + field + " " + value + ", "
+			}
+		}
+
+		order = strings.TrimSuffix(order, ", ")
+
+		queryParams = queryParams + order
+	}
+
+	queryParams = queryParams + " LIMIT " + qp.Limit
+	queryParams = queryParams + " OFFSET " + qp.Offset
+
+	movieList, err := m.movieStorage.SelectAllMovies(queryParams)
+	if err != nil {
+		return nil, fmt.Errorf("service Get got the error: %w", err)
+	}
+
+	return movieList, nil
 }

--- a/backend/app/service/movie.go
+++ b/backend/app/service/movie.go
@@ -2,8 +2,6 @@ package service
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/Brigant/PetPorject/backend/app/core"
 )
@@ -39,46 +37,25 @@ func (m MovieService) Get(movieID string) (core.Movie, error) {
 // The general meaning of this service is to generate sql query parameter
 // and get the movie list from the database using that query parameter.
 func (m MovieService) GetList(qp core.QueryParams) ([]core.Movie, error) {
-	var queryCondition string
-
-	if len(qp.Filter) > 0 {
-		where := "WHERE "
-
-		for i := 0; i < len(qp.Filter); i++ {
-			if qp.Filter[i].Val != "" {
-				if _, err := strconv.Atoi(qp.Filter[i].Val); err == nil {
-					where = where + qp.Filter[i].Key + ">=" + qp.Filter[i].Val + " AND "
-				} else {
-					where = where + qp.Filter[i].Key + "='" + qp.Filter[i].Val + "' AND "
-				}
-			}
-		}
-
-		where = strings.TrimSuffix(where, "AND ")
-
-		queryCondition = queryCondition + where
-	}
-
-	if len(qp.Sort) > 0 {
-		order := "ORDER BY "
-
-		for i := 0; i < len(qp.Sort); i++ {
-			if qp.Sort[i].Val != "" {
-				order = order + qp.Sort[i].Key + " " + qp.Sort[i].Val + ", "
-			}
-		}
-
-		order = strings.TrimSuffix(order, ", ")
-
-		queryCondition = queryCondition + order
-	}
-
-	queryCondition = queryCondition + " LIMIT " + qp.Limit
-	queryCondition = queryCondition + " OFFSET " + qp.Offset
-
-	movieList, err := m.movieStorage.SelectAllMovies(queryCondition)
+	movieList, err := m.movieStorage.SelectAllMovies(qp)
 	if err != nil {
 		return nil, fmt.Errorf("error while selecting movies: %w", err)
+	}
+
+	return movieList, nil
+}
+
+// Prepare the movie list slice for export.
+func (m MovieService) GetCSV(qp core.QueryParams) ([]core.MovieCSV, error) {
+	const SecondsInMinutes = 60
+	movieList, err := m.movieStorage.SelectMoviesCSV(qp)
+	if err != nil {
+		return nil, fmt.Errorf("error while SelectMoviesCSV: %w", err)
+	}
+
+	for i := 0; i < len(movieList); i++ {
+		movieList[i].Number = i + 1
+		movieList[i].Duration = movieList[i].Duration / SecondsInMinutes
 	}
 
 	return movieList, nil

--- a/backend/app/service/movie.go
+++ b/backend/app/service/movie.go
@@ -48,6 +48,7 @@ func (m MovieService) GetList(qp core.QueryParams) ([]core.Movie, error) {
 // Prepare the movie list slice for export.
 func (m MovieService) GetCSV(qp core.QueryParams) ([]core.MovieCSV, error) {
 	const SecondsInMinutes = 60
+
 	movieList, err := m.movieStorage.SelectMoviesCSV(qp)
 	if err != nil {
 		return nil, fmt.Errorf("error while SelectMoviesCSV: %w", err)
@@ -55,7 +56,7 @@ func (m MovieService) GetCSV(qp core.QueryParams) ([]core.MovieCSV, error) {
 
 	for i := 0; i < len(movieList); i++ {
 		movieList[i].Number = i + 1
-		movieList[i].Duration = movieList[i].Duration / SecondsInMinutes
+		movieList[i].Duration /= SecondsInMinutes
 	}
 
 	return movieList, nil

--- a/backend/app/service/movieService_test.go
+++ b/backend/app/service/movieService_test.go
@@ -120,16 +120,15 @@ func TestMovieService_get(t *testing.T) {
 }
 
 func TestMovieService_GetList(t *testing.T) {
-	type mockBehavior func(s *MockMovieStorage, queryParams string)
+	type mockBehavior func(s *MockMovieStorage, queryParams core.QueryParams)
 
 	testCasesTable := map[string]struct {
 		queryParams          core.QueryParams
-		queryConfition       string
 		mockBehavior         mockBehavior
 		expectedErrorMessage string
 		wantError            bool
 	}{
-		"Where check": {
+		"Successful case": {
 			queryParams: core.QueryParams{
 				Filter: []core.QuerySliceElement{
 					{Key: "genre", Val: "comedy"},
@@ -138,33 +137,14 @@ func TestMovieService_GetList(t *testing.T) {
 				Limit:  "20",
 				Offset: "1",
 			},
-			mockBehavior: func(s *MockMovieStorage, queryCondition string) {
+			mockBehavior: func(s *MockMovieStorage, queryCondition core.QueryParams) {
 				s.EXPECT().SelectAllMovies(queryCondition).Return([]core.Movie{
 					{ID: "some-movie-id"},
 				}, nil)
 			},
-			queryConfition: `WHERE genre='comedy' AND rate>=5  LIMIT 20 OFFSET 1`,
-			wantError:      false,
+			wantError: false,
 		},
-		"Sort check": {
-			queryParams: core.QueryParams{
-				Sort: []core.QuerySliceElement{
-					{Key: "release_date", Val: "dsc"},
-					{Key: "rate", Val: "asc"},
-					{Key: "duration", Val: "dsc"},
-				},
-				Limit:  "20",
-				Offset: "1",
-			},
-			mockBehavior: func(s *MockMovieStorage, queryCondition string) {
-				s.EXPECT().SelectAllMovies(queryCondition).Return([]core.Movie{
-					{ID: "some-movie-id"},
-				}, nil)
-			},
-			queryConfition: `ORDER BY release_date dsc, rate asc, duration dsc LIMIT 20 OFFSET 1`,
-			wantError:      false,
-		},
-		"Some error": {
+		"Error case": {
 			queryParams: core.QueryParams{
 				Filter: []core.QuerySliceElement{
 					{Key: "genre", Val: "comedy"},
@@ -173,11 +153,10 @@ func TestMovieService_GetList(t *testing.T) {
 				Limit:  "20",
 				Offset: "1",
 			},
-			mockBehavior: func(s *MockMovieStorage, queryCondition string) {
+			mockBehavior: func(s *MockMovieStorage, queryCondition core.QueryParams) {
 				s.EXPECT().SelectAllMovies(queryCondition).Return(nil,
 					errors.New("some error"))
 			},
-			queryConfition:       `WHERE genre='comedy' AND rate>=5  LIMIT 20 OFFSET 1`,
 			expectedErrorMessage: "error while selecting movies: some error",
 			wantError:            true,
 		},
@@ -189,13 +168,80 @@ func TestMovieService_GetList(t *testing.T) {
 			defer ctrl.Finish()
 
 			mStorage := NewMockMovieStorage(ctrl)
-			testCase.mockBehavior(mStorage, testCase.queryConfition)
+			testCase.mockBehavior(mStorage, testCase.queryParams)
 
 			ms := MovieService{
 				movieStorage: mStorage,
 			}
 
 			_, err := ms.GetList(testCase.queryParams)
+
+			if testCase.wantError {
+				assert.EqualError(t, err, testCase.expectedErrorMessage,
+					"We want get an error beceause the storage returned the error")
+			} else {
+				assert.NoError(t, err, "The error should be nil")
+			}
+		})
+	}
+}
+
+func TestMovieService_GetCSV(t *testing.T) {
+	type mockBehavior func(s *MockMovieStorage, queryParams core.QueryParams)
+
+	testCasesTable := map[string]struct {
+		queryParams          core.QueryParams
+		mockBehavior         mockBehavior
+		expectedErrorMessage string
+		wantError            bool
+	}{
+		"Successful case": {
+			queryParams: core.QueryParams{
+				Filter: []core.QuerySliceElement{
+					{Key: "genre", Val: "comedy"},
+					{Key: "rate", Val: "5"},
+				},
+				Limit:  "20",
+				Offset: "1",
+			},
+			mockBehavior: func(s *MockMovieStorage, queryCondition core.QueryParams) {
+				s.EXPECT().SelectMoviesCSV(queryCondition).Return([]core.MovieCSV{
+					{Title: "some-title"},
+				}, nil)
+			},
+			wantError: false,
+		},
+		"Error case": {
+			queryParams: core.QueryParams{
+				Filter: []core.QuerySliceElement{
+					{Key: "genre", Val: "comedy"},
+					{Key: "rate", Val: "5"},
+				},
+				Limit:  "20",
+				Offset: "1",
+			},
+			mockBehavior: func(s *MockMovieStorage, queryCondition core.QueryParams) {
+				s.EXPECT().SelectMoviesCSV(queryCondition).Return(nil,
+					errors.New("some error"))
+			},
+			expectedErrorMessage: "error while SelectMoviesCSV: some error",
+			wantError:            true,
+		},
+	}
+
+	for name, testCase := range testCasesTable {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mStorage := NewMockMovieStorage(ctrl)
+			testCase.mockBehavior(mStorage, testCase.queryParams)
+
+			ms := MovieService{
+				movieStorage: mStorage,
+			}
+
+			_, err := ms.GetCSV(testCase.queryParams)
 
 			if testCase.wantError {
 				assert.EqualError(t, err, testCase.expectedErrorMessage,

--- a/backend/app/transport/rest/handler/contract.go
+++ b/backend/app/transport/rest/handler/contract.go
@@ -21,6 +21,7 @@ type DirectorService interface {
 type MovieService interface {
 	CreateMovie(movie core.Movie) error
 	Get(movieID string) (core.Movie, error)
+	GetList(core.QueryParams) ([]core.Movie, error)
 }
 
 type ListsService interface {

--- a/backend/app/transport/rest/handler/contract.go
+++ b/backend/app/transport/rest/handler/contract.go
@@ -22,6 +22,7 @@ type MovieService interface {
 	CreateMovie(movie core.Movie) error
 	Get(movieID string) (core.Movie, error)
 	GetList(core.QueryParams) ([]core.Movie, error)
+	GetCSV(core.QueryParams) ([]core.MovieCSV, error)
 }
 
 type ListsService interface {

--- a/backend/app/transport/rest/handler/contract_mock_test.go
+++ b/backend/app/transport/rest/handler/contract_mock_test.go
@@ -228,6 +228,21 @@ func (mr *MockMovieServiceMockRecorder) Get(movieID interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockMovieService)(nil).Get), movieID)
 }
 
+// GetCSV mocks base method.
+func (m *MockMovieService) GetCSV(arg0 core.QueryParams) ([]core.MovieCSV, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCSV", arg0)
+	ret0, _ := ret[0].([]core.MovieCSV)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCSV indicates an expected call of GetCSV.
+func (mr *MockMovieServiceMockRecorder) GetCSV(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCSV", reflect.TypeOf((*MockMovieService)(nil).GetCSV), arg0)
+}
+
 // GetList mocks base method.
 func (m *MockMovieService) GetList(arg0 core.QueryParams) ([]core.Movie, error) {
 	m.ctrl.T.Helper()

--- a/backend/app/transport/rest/handler/contract_mock_test.go
+++ b/backend/app/transport/rest/handler/contract_mock_test.go
@@ -228,6 +228,21 @@ func (mr *MockMovieServiceMockRecorder) Get(movieID interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockMovieService)(nil).Get), movieID)
 }
 
+// GetList mocks base method.
+func (m *MockMovieService) GetList(arg0 core.QueryParams) ([]core.Movie, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetList", arg0)
+	ret0, _ := ret[0].([]core.Movie)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetList indicates an expected call of GetList.
+func (mr *MockMovieServiceMockRecorder) GetList(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetList", reflect.TypeOf((*MockMovieService)(nil).GetList), arg0)
+}
+
 // MockListsService is a mock of ListsService interface.
 type MockListsService struct {
 	ctrl     *gomock.Controller

--- a/backend/app/transport/rest/handler/directorHandler_test.go
+++ b/backend/app/transport/rest/handler/directorHandler_test.go
@@ -60,7 +60,7 @@ func TestDirector_create(t *testing.T) {
 			mockBehavior: func(s *MockDirectorService, director core.Director) {
 			},
 			expectedStatusCode:  http.StatusBadRequest,
-			expectedRequestBody: `{"error":"parsing time \"20222-12-30\" as \"2006-01-02\": cannot parse \"2-12-30\" as \"-\""}`,
+			expectedRequestBody: `{"error":"date parsing error: parsing time \"20222-12-30\" as \"2006-01-02\": cannot parse \"2-12-30\" as \"-\""}`,
 		},
 		"service return error": {
 			logger:    log,
@@ -211,7 +211,7 @@ func TestDirector_get(t *testing.T) {
 		"Internal error": {
 			logger: log,
 			mockBehavior: func(s *MockDirectorService) {
-				s.EXPECT().GetDirectorList().Return([]core.Director{}, 
+				s.EXPECT().GetDirectorList().Return([]core.Director{},
 					errors.New("some internal error"))
 			},
 			expectedStatusCode:  http.StatusInternalServerError,

--- a/backend/app/transport/rest/handler/movie.go
+++ b/backend/app/transport/rest/handler/movie.go
@@ -125,7 +125,14 @@ func (h *MovieHandler) getAll(c *gin.Context) {
 
 	movieList, err := h.service.GetList(qp)
 	if err != nil {
-		h.logger.Debugw("bad query", "error", err.Error())
+		if errors.Is(err, core.ErrMovieNotFound) {
+			h.logger.Debugw("bad query", "alert", err.Error())
+			c.JSON(http.StatusOK, gin.H{"alert": err.Error()})
+
+			return
+		}
+
+		h.logger.Debugw("Service Getlist", "error", err.Error())
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 
 		return

--- a/backend/app/transport/rest/handler/movieHandler_test.go
+++ b/backend/app/transport/rest/handler/movieHandler_test.go
@@ -31,7 +31,7 @@ func TestMovie_create(t *testing.T) {
 		"Successful case": {
 			inputBody: `{
 				"title":"Avatar2",
-				"ganre":"Adventure",
+				"genre":"Adventure",
 				"director_id": "bed41cca-ee04-4975-ad7e-5b142e8a9306",
 				"rate":1,
 				"release_date":"2023-01-01",
@@ -46,7 +46,7 @@ func TestMovie_create(t *testing.T) {
 		"Bad json": {
 			inputBody: `
 				"titl":"Avatar2",
-				"ganre":"Adventure",
+				"genre":"Adventure",
 				"director_id": "bed41cca-ee04-4975-ad7e-5b142e8a9306",
 				"rate":1,
 				"release_date":"2023-01-01",
@@ -60,7 +60,7 @@ func TestMovie_create(t *testing.T) {
 		"Empty title": {
 			inputBody: `{
 				"title":"",
-				"ganre":"Adventure",
+				"genre":"Adventure",
 				"director_id": "bed41cca-ee04-4975-ad7e-5b142e8a9306",
 				"rate":1,
 				"release_date":"2023-01-01",
@@ -71,10 +71,10 @@ func TestMovie_create(t *testing.T) {
 			expectedStatusCode:   http.StatusBadRequest,
 			expectedResponseBody: `{"error":"Key: 'Movie.Title' Error:Field validation for 'Title' failed on the 'required' tag"}`,
 		},
-		"Empty ganre": {
+		"Empty genre": {
 			inputBody: `{
 				"title":"Avatar2",
-				"ganre":"",
+				"genre":"",
 				"director_id": "bed41cca-ee04-4975-ad7e-5b142e8a9306",
 				"rate":1,
 				"release_date":"2023-01-01",
@@ -83,12 +83,12 @@ func TestMovie_create(t *testing.T) {
 			mockBehavior: func(s *MockMovieService, movie core.Movie) {
 			},
 			expectedStatusCode:   http.StatusBadRequest,
-			expectedResponseBody: `{"error":"Key: 'Movie.Ganre' Error:Field validation for 'Ganre' failed on the 'required' tag"}`,
+			expectedResponseBody: `{"error":"Key: 'Movie.Genre' Error:Field validation for 'Genre' failed on the 'required' tag"}`,
 		},
 		"Wrong director ID": {
 			inputBody: `{
 				"title":"Avatar2",
-				"ganre":"Adventure",
+				"genre":"Adventure",
 				"director_id": "wrong-uuid",
 				"rate":1,
 				"release_date":"2023-01-01",
@@ -102,7 +102,7 @@ func TestMovie_create(t *testing.T) {
 		"To low rate": {
 			inputBody: `{
 				"title":"Avatar2",
-				"ganre":"Adventure",
+				"genre":"Adventure",
 				"director_id": "bed41cca-ee04-4975-ad7e-5b142e8a9306",
 				"rate":-1,
 				"release_date":"2023-01-01",
@@ -116,7 +116,7 @@ func TestMovie_create(t *testing.T) {
 		"To hight rate": {
 			inputBody: `{
 				"title":"Avatar2",
-				"ganre":"Adventure",
+				"genre":"Adventure",
 				"director_id": "bed41cca-ee04-4975-ad7e-5b142e8a9306",
 				"rate":11,
 				"release_date":"2023-01-01",
@@ -130,7 +130,7 @@ func TestMovie_create(t *testing.T) {
 		"To low duration": {
 			inputBody: `{
 				"title":"Avatar2",
-				"ganre":"Adventure",
+				"genre":"Adventure",
 				"director_id": "bed41cca-ee04-4975-ad7e-5b142e8a9306",
 				"rate":5,
 				"release_date":"2023-01-01",
@@ -144,7 +144,7 @@ func TestMovie_create(t *testing.T) {
 		"Err Foreign Key Violation": {
 			inputBody: `{
 				"title":"Avatar2",
-				"ganre":"Adventure",
+				"genre":"Adventure",
 				"director_id": "bed41cca-ee04-4975-ad7e-5b142e8a9306",
 				"rate":1,
 				"release_date":"2023-01-01",
@@ -159,7 +159,7 @@ func TestMovie_create(t *testing.T) {
 		"Err Unique Movie": {
 			inputBody: `{
 				"title":"Avatar2",
-				"ganre":"Adventure",
+				"genre":"Adventure",
 				"director_id": "bed41cca-ee04-4975-ad7e-5b142e8a9306",
 				"rate":1,
 				"release_date":"2023-01-01",
@@ -174,7 +174,7 @@ func TestMovie_create(t *testing.T) {
 		"Internal Service Error": {
 			inputBody: `{
 				"title":"Avatar2",
-				"ganre":"Adventure",
+				"genre":"Adventure",
 				"director_id": "bed41cca-ee04-4975-ad7e-5b142e8a9306",
 				"rate":1,
 				"release_date":"2023-01-01",
@@ -243,7 +243,7 @@ func TestMovie_get(t *testing.T) {
 				}, nil)
 			},
 			expectedStatusCode:   http.StatusOK,
-			expectedResponseBody: `{"id":"6b823d5e-3d37-4617-a568-226e2e31a4f4","title":"TestTitle","ganre":"","director_id":"","rate":0,"release_date":"","duration":0,"created":"","modified":""}`,
+			expectedResponseBody: `{"id":"6b823d5e-3d37-4617-a568-226e2e31a4f4","title":"TestTitle","genre":"","director_id":"","rate":0,"release_date":"","duration":0,"created":"","modified":""}`,
 		},
 		"Not found in params": {
 			inputID:              "6b823d5e-3d37-4617-a568-226e2e31a4f4",
@@ -267,7 +267,7 @@ func TestMovie_get(t *testing.T) {
 					core.ErrMovieNotFound)
 			},
 			expectedStatusCode:   http.StatusNotFound,
-			expectedResponseBody: `{"error":"no movie with such ID"}`,
+			expectedResponseBody: `{"error":"no movie was found"}`,
 		},
 		"Internal server error": {
 			inputID:   "6b823d5e-3d37-4617-a568-226e2e31a4f4",
@@ -300,6 +300,119 @@ func TestMovie_get(t *testing.T) {
 			c.Request = httptest.NewRequest(http.MethodGet, "/movie/"+testCase.inputID, nil)
 
 			r.GET("/movie/:"+testCase.paramName, mh.get)
+
+			r.ServeHTTP(w, c.Request)
+
+			assert.Equal(t, testCase.expectedStatusCode, w.Code)
+			assert.Equal(t, testCase.expectedResponseBody, w.Body.String())
+		})
+	}
+}
+
+func TestMovie_getAll(t *testing.T) {
+	log, err := logger.New("INFO")
+	if err != nil {
+		t.FailNow()
+	}
+
+	type mockBehavior func(s *MockMovieService)
+	testCasesTable := map[string]struct {
+		queryPath            string
+		mockBehavior         mockBehavior
+		expectedStatusCode   int
+		expectedResponseBody string
+	}{
+		"Successful case": {
+			queryPath: "/movie/?offset=1&limit=50&f[genre]=comedy&f[rate]=2&s[rate]=asc&s[duration]=dsc&s[release_date]=asc",
+			mockBehavior: func(s *MockMovieService) {
+				s.EXPECT().GetList(gomock.Any()).Return([]core.Movie{
+					{ID: "movie-id-1"},
+				}, nil).Times(1)
+			},
+			expectedStatusCode:   http.StatusOK,
+			expectedResponseBody: `[{"id":"movie-id-1","title":"","genre":"","director_id":"","rate":0,"release_date":"","duration":0,"created":"","modified":""}]`,
+		},
+		"Internal Server error": {
+			queryPath: "/movie/?f[genre]=comedy",
+			mockBehavior: func(s *MockMovieService) {
+				s.EXPECT().GetList(gomock.Any()).Return(nil,
+					errors.New("some error")).Times(1)
+			},
+			expectedStatusCode:   http.StatusInternalServerError,
+			expectedResponseBody: `{"error":"some error"}`,
+		},
+		"Alert emtpty return": {
+			queryPath: "/movie/?f[genre]=comedy",
+			mockBehavior: func(s *MockMovieService) {
+				s.EXPECT().GetList(gomock.Any()).Return(nil,
+					core.ErrMovieNotFound).Times(1)
+			},
+			expectedStatusCode:   http.StatusOK,
+			expectedResponseBody: `{"alert":"no movie was found"}`,
+		},
+		"Wronge filter key": {
+			queryPath:            "/movie/?f[gAnre]=comedy",
+			mockBehavior:         func(s *MockMovieService) {},
+			expectedStatusCode:   http.StatusBadRequest,
+			expectedResponseBody: `{"error":"unallowed filter key"}`,
+		},
+		"Wronge rate value": {
+			queryPath:            "/movie/?f[rate]=badData",
+			mockBehavior:         func(s *MockMovieService) {},
+			expectedStatusCode:   http.StatusBadRequest,
+			expectedResponseBody: `{"error":"the value shlould be an integer: strconv.Atoi: parsing \"badData\": invalid syntax"}`,
+		},
+		"Rate value outrange": {
+			queryPath:            "/movie/?f[rate]=11",
+			mockBehavior:         func(s *MockMovieService) {},
+			expectedStatusCode:   http.StatusBadRequest,
+			expectedResponseBody: `{"error":"the value should be in range from 1 to 10 :unallowed rate value"}`,
+		},
+		"Wrong sort key": {
+			queryPath:            "/movie/?s[wrong]=asc",
+			mockBehavior:         func(s *MockMovieService) {},
+			expectedStatusCode:   http.StatusBadRequest,
+			expectedResponseBody: `{"error":"key wrong is bad: unallowed sort"}`,
+		},
+		"Wrong sort value": {
+			queryPath:            "/movie/?s[duration]=value",
+			mockBehavior:         func(s *MockMovieService) {},
+			expectedStatusCode:   http.StatusBadRequest,
+			expectedResponseBody: `{"error":"the sort value: unallowed sort"}`,
+		},
+		"Unallowed limit value": {
+			queryPath:            "/movie/?limit=1000",
+			mockBehavior:         func(s *MockMovieService) {},
+			expectedStatusCode:   http.StatusBadRequest,
+			expectedResponseBody: `{"error":"unallowed limit"}`,
+		},
+		"Unallowed offset value": {
+			queryPath:            "/movie/?offset=1001",
+			mockBehavior:         func(s *MockMovieService) {},
+			expectedStatusCode:   http.StatusBadRequest,
+			expectedResponseBody: `{"error":"offset should be in range from 0 to 1000: unallowed offset"}`,
+		},
+	}
+
+	for name, testCase := range testCasesTable {
+		t.Run(name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			movieService := NewMockMovieService(ctrl)
+			testCase.mockBehavior(movieService)
+
+			mh := NewMovieHandler(movieService, log)
+
+			w := httptest.NewRecorder()
+
+			c, r := gin.CreateTestContext(w)
+
+			c.Request = httptest.NewRequest(http.MethodGet, testCase.queryPath, nil)
+
+			r.GET("/movie/", mh.getAll)
 
 			r.ServeHTTP(w, c.Request)
 

--- a/backend/migrations/4_create_movie_table.up.sql
+++ b/backend/migrations/4_create_movie_table.up.sql
@@ -2,7 +2,7 @@ CREATE TABLE "movie" (
    "id" uuid DEFAULT gen_random_uuid() NOT NULL,
    "director_id" uuid NOT NULL,
    "title" VARCHAR(255) NOT NULL,
-   "ganre" VARCHAR(255) NOT NULL,
+   "genre" VARCHAR(255) NOT NULL,
    "rate" INT NOT NULL,
    "release_date" Timestamp Without Time Zone NOT NULL,
    "duration" INT NOT NULL DEFAULT 0,

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/gocarina/gocsv v0.0.0-20230406101422-6445c2b15027 // indirect
 	github.com/goccy/go-json v0.10.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/go-playground/validator/v10 v10.11.2 h1:q3SHpufmypg+erIExEKUmsgmhDTyh
 github.com/go-playground/validator/v10 v10.11.2/go.mod h1:NieE624vt4SCTJtD87arVLvdmjPAeV8BQlHtMnw9D7s=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/gocarina/gocsv v0.0.0-20230406101422-6445c2b15027 h1:LCGzZb4kMUUjMUzLxxqSJBwo9szUO0tK8cOxnEOT4Jc=
+github.com/gocarina/gocsv v0.0.0-20230406101422-6445c2b15027/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
 github.com/goccy/go-json v0.10.0 h1:mXKd9Qw4NuzShiRlOXKews24ufknHO7gx30lsDyokKA=
 github.com/goccy/go-json v0.10.0/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=


### PR DESCRIPTION
---

**What needs to be done**
We need to get a movie list with the paginator and with the possibility to filter by genre or rate and with the capability of sorting by rate or duration, or release date

It is need the functionality to get that list in csv format

---
**Why it needs to be done**
Paginator must have cause of to avoid of overload the server with the havy requests

Filtration is needed for user convenience

Sorting is needed for user convenience

---
**Acceptance criteria**
Endpoint should accept the query parameters of the paginator, filter, and sorting.

Paginator should accept only these values: 20, 50, and 100. If the paginator is not defined the server should return 20 movies by default

The filter should restrict the response according to the specified value. The available filter values are: genre, rate. If no filter is cpesified, it should response all available movies.

Sorting should sort the response movie list in descending order with the specified values. The available values for sorting are rate, release date, and duration. If no sort parameter is specified, it should respons with rate by default.

When the export query parameter is checked the response should returne the data is csv format.