### PR TITLE
Feat: add endpoint create list

### DIFF
--- a/backend/app/core/account.go
+++ b/backend/app/core/account.go
@@ -24,9 +24,10 @@ type TokenPair struct {
 const Salt = "BlaBlaBla"
 
 var (
-	ErrDuplicatePhone = errors.New("phone is already exists in the database")
-	ErrUserNotFound   = errors.New("user is not found with such credentials")
-	ErrWrongPassword  = errors.New("wrong passord")
+	ErrDuplicatePhone        = errors.New("phone is already exists in the database")
+	ErrUserNotFound          = errors.New("user is not found with such credentials")
+	ErrWrongPassword         = errors.New("wrong passord")
+	ErrContexAccountNotFound = errors.New("no account found in contex")
 )
 
 func SHA256(password, salt string) string {

--- a/backend/app/core/list.go
+++ b/backend/app/core/list.go
@@ -1,15 +1,18 @@
 package core
 
-type FavoriteList struct {
-	ID       string `json:"id"`
-	FilmID   string `json:"film_id"`
-	Created  string `json:"created"`
-	Modified string `json:"modified"`
+import (
+	"errors"
+
+	"github.com/google/uuid"
+)
+
+type MovieList struct {
+	ID        uuid.UUID `json:"id" db:"id"`
+	Type      string    `json:"type" db:"type"`
+	AccountID uuid.UUID `json:"account_id" db:"account_id"`
+	MovieID   uuid.UUID `json:"movie_id" db:"movie_id"`
+	Created   string    `json:"created" db:"created"`
+	Modified  string    `json:"modified" db:"modified"`
 }
 
-type WhishList struct {
-	ID       string `json:"id"`
-	FilmID   string `json:"film_id"`
-	Created  string `json:"created"`
-	Modified string `json:"modified"`
-}
+var ErrDuplicateRow = errors.New("the account has that list type")

--- a/backend/app/core/list.go
+++ b/backend/app/core/list.go
@@ -15,4 +15,20 @@ type MovieList struct {
 	Modified  string    `json:"modified" db:"modified"`
 }
 
-var ErrDuplicateRow = errors.New("the account has that list type")
+var (
+	ErrDuplicateRow       = errors.New("the account has that list type")
+	ErrEmptyMovieListType = errors.New("the movie list type should't be empty")
+	ErrEpmtryMovieID      = errors.New("the movie ID should't be empty")
+)
+
+func (ml MovieList) Validate() error {
+	if ml.Type == "" {
+		return ErrEmptyMovieListType
+	}
+
+	if ml.MovieID == uuid.Nil {
+		return ErrEpmtryMovieID
+	}
+
+	return nil
+}

--- a/backend/app/repositorie/pg/list.go
+++ b/backend/app/repositorie/pg/list.go
@@ -28,11 +28,15 @@ func (d ListDB) Insert(list core.MovieList) (string, error) {
 		if errors.As(err, &pqErr) && pqErr.Code.Name() == ErrCodeUniqueViolation {
 			return "", core.ErrDuplicateRow
 		}
+
 		return "", fmt.Errorf("insterting error: %w", err)
 	}
+	defer rows.Close()
 
 	var listID string
+
 	rows.Next()
+
 	if err := rows.Scan(&listID); err != nil {
 		return "", fmt.Errorf("error while scaning: %w", err)
 	}

--- a/backend/app/repositorie/pg/list.go
+++ b/backend/app/repositorie/pg/list.go
@@ -1,0 +1,41 @@
+package pg
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Brigant/PetPorject/backend/app/core"
+	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
+)
+
+type ListDB struct {
+	db *sqlx.DB
+}
+
+func NewListDB(db *sqlx.DB) ListDB {
+	return ListDB{db: db}
+}
+
+func (d ListDB) Insert(list core.MovieList) (string, error) {
+	// _ = list
+	query := `INSERT INTO public.list(type, account_id, movie_id)
+		VALUES(:type, :account_id, :movie_id) RETURNING id`
+
+	rows, err := d.db.NamedQuery(query, &list)
+	if err != nil {
+		pqErr := new(pq.Error)
+		if errors.As(err, &pqErr) && pqErr.Code.Name() == ErrCodeUniqueViolation {
+			return "", core.ErrDuplicateRow
+		}
+		return "", fmt.Errorf("insterting error: %w", err)
+	}
+
+	var listID string
+	rows.Next()
+	if err := rows.Scan(&listID); err != nil {
+		return "", fmt.Errorf("error while scaning: %w", err)
+	}
+
+	return listID, nil
+}

--- a/backend/app/repositorie/pg/postgres.go
+++ b/backend/app/repositorie/pg/postgres.go
@@ -18,6 +18,7 @@ type Repository struct {
 	AccountDB  AccountDB
 	DirectorDB DirectorDB
 	MovieDB    MovieDB
+	ListDB     ListDB
 }
 
 // NewPostgresDB function returns object of datatabase.
@@ -37,5 +38,6 @@ func NewRepository(db *sqlx.DB) Repository {
 		AccountDB:  NewAccountDB(db),
 		DirectorDB: NewDirectorDB(db),
 		MovieDB:    NewMovieDB(db),
+		ListDB:     NewListDB(db),
 	}
 }

--- a/backend/app/service/contract.go
+++ b/backend/app/service/contract.go
@@ -28,3 +28,7 @@ type MovieStorage interface {
 	SelectMoviesCSV(qp core.QueryParams) ([]core.MovieCSV, error)
 	SelectMovieByID(movieID string) (core.Movie, error)
 }
+
+type ListSorage interface {
+	Insert(core.MovieList) (string, error)
+}

--- a/backend/app/service/contract_mock_test.go
+++ b/backend/app/service/contract_mock_test.go
@@ -285,3 +285,41 @@ func (mr *MockMovieStorageMockRecorder) SelectMoviesCSV(qp interface{}) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectMoviesCSV", reflect.TypeOf((*MockMovieStorage)(nil).SelectMoviesCSV), qp)
 }
+
+// MockListSorage is a mock of ListSorage interface.
+type MockListSorage struct {
+	ctrl     *gomock.Controller
+	recorder *MockListSorageMockRecorder
+}
+
+// MockListSorageMockRecorder is the mock recorder for MockListSorage.
+type MockListSorageMockRecorder struct {
+	mock *MockListSorage
+}
+
+// NewMockListSorage creates a new mock instance.
+func NewMockListSorage(ctrl *gomock.Controller) *MockListSorage {
+	mock := &MockListSorage{ctrl: ctrl}
+	mock.recorder = &MockListSorageMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockListSorage) EXPECT() *MockListSorageMockRecorder {
+	return m.recorder
+}
+
+// Insert mocks base method.
+func (m *MockListSorage) Insert(arg0 core.MovieList) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Insert", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Insert indicates an expected call of Insert.
+func (mr *MockListSorageMockRecorder) Insert(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Insert", reflect.TypeOf((*MockListSorage)(nil).Insert), arg0)
+}

--- a/backend/app/service/list.go
+++ b/backend/app/service/list.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/Brigant/PetPorject/backend/app/core"
+)
+
+type ListService struct {
+	storage ListSorage
+}
+
+func NewListService(storage ListSorage) ListService {
+	return ListService{storage: storage}
+}
+
+func (s ListService) Create(list core.MovieList) (string, error) {
+	listID, err := s.storage.Insert(list)
+	if err != nil {
+		return "", fmt.Errorf("create service got an error: %w", err)
+	}
+
+	return listID, nil
+}

--- a/backend/app/service/list_test.go
+++ b/backend/app/service/list_test.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Brigant/PetPorject/backend/app/core"
+	gomock "github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListService_create(t *testing.T) {
+	type mockBehavior func(s *MockListSorage, list core.MovieList)
+
+	testCasesTable := map[string]struct {
+		list                 core.MovieList
+		mockBehavior         mockBehavior
+		expectedErrorMessage string
+		expectedID           string
+		wantError            bool
+	}{
+		"Successful": {
+			list: core.MovieList{},
+			mockBehavior: func(s *MockListSorage, list core.MovieList) {
+				s.EXPECT().Insert(list).Return("listID-111", nil).Times(1)
+			},
+			expectedID:           "listID-111",
+			expectedErrorMessage: "",
+			wantError:            false,
+		},
+		"Shoud be an error": {
+			list: core.MovieList{},
+			mockBehavior: func(s *MockListSorage, list core.MovieList) {
+				s.EXPECT().Insert(list).Return("",
+					errors.New("some error")).Times(1)
+			},
+			expectedID:           "",
+			expectedErrorMessage: "create service got an error: some error",
+			wantError:            true,
+		},
+	}
+
+	for name, testCase := range testCasesTable {
+		t.Run(name, func(t *testing.T) {
+			// Init Deps
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			listStorage := NewMockListSorage(ctrl)
+			testCase.mockBehavior(listStorage, testCase.list)
+
+			ls := ListService{
+				storage: listStorage,
+			}
+
+			listID, err := ls.Create(testCase.list)
+
+			if testCase.wantError {
+				assert.EqualError(t, err, testCase.expectedErrorMessage,
+					"We want get an error beceause the storage returned the error")
+			} else {
+				assert.NoError(t, err, "The error should be nil")
+				assert.Equal(t, testCase.expectedID, listID)
+			}
+		})
+	}
+}

--- a/backend/app/service/service.go
+++ b/backend/app/service/service.go
@@ -4,12 +4,14 @@ type Deps struct {
 	AccountStorage  AccountStorage
 	DirectorStorage DirectorStorage
 	MovieStorage    MovieStorage
+	ListSorage      ListSorage
 }
 
 type Services struct {
 	Account  AccountService
 	Director DirectorService
 	Movie    MovieService
+	List     ListService
 }
 
 func New(deps Deps) Services {
@@ -17,5 +19,6 @@ func New(deps Deps) Services {
 		Account:  NewAccountService(deps.AccountStorage),
 		Director: NewDirectorService(deps.DirectorStorage),
 		Movie:    NewMovieService(deps.MovieStorage),
+		List:     NewListService(deps.ListSorage),
 	}
 }

--- a/backend/app/transport/rest/handler/account.go
+++ b/backend/app/transport/rest/handler/account.go
@@ -32,7 +32,9 @@ type inputRefreshToken struct {
 	RefreshToken uuid.UUID `json:"refreshToken"`
 }
 
-var errInvalidRefreshToken = errors.New("invalid refresh token")
+var (
+	errInvalidRefreshToken   = errors.New("invalid refresh token")
+)
 
 func (h AccountHandler) singUp(c *gin.Context) {
 	var account core.Account

--- a/backend/app/transport/rest/handler/account.go
+++ b/backend/app/transport/rest/handler/account.go
@@ -32,9 +32,7 @@ type inputRefreshToken struct {
 	RefreshToken uuid.UUID `json:"refreshToken"`
 }
 
-var (
-	errInvalidRefreshToken   = errors.New("invalid refresh token")
-)
+var errInvalidRefreshToken = errors.New("invalid refresh token")
 
 func (h AccountHandler) singUp(c *gin.Context) {
 	var account core.Account

--- a/backend/app/transport/rest/handler/contract.go
+++ b/backend/app/transport/rest/handler/contract.go
@@ -26,5 +26,5 @@ type MovieService interface {
 }
 
 type ListsService interface {
-	CreateMovie() (string, error)
+	Create(list core.MovieList) (string, error)
 }

--- a/backend/app/transport/rest/handler/contract_mock_test.go
+++ b/backend/app/transport/rest/handler/contract_mock_test.go
@@ -281,17 +281,17 @@ func (m *MockListsService) EXPECT() *MockListsServiceMockRecorder {
 	return m.recorder
 }
 
-// CreateMovie mocks base method.
-func (m *MockListsService) CreateMovie() (string, error) {
+// Create mocks base method.
+func (m *MockListsService) Create(list core.MovieList) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateMovie")
+	ret := m.ctrl.Call(m, "Create", list)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CreateMovie indicates an expected call of CreateMovie.
-func (mr *MockListsServiceMockRecorder) CreateMovie() *gomock.Call {
+// Create indicates an expected call of Create.
+func (mr *MockListsServiceMockRecorder) Create(list interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMovie", reflect.TypeOf((*MockListsService)(nil).CreateMovie))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockListsService)(nil).Create), list)
 }

--- a/backend/app/transport/rest/handler/handler.go
+++ b/backend/app/transport/rest/handler/handler.go
@@ -31,7 +31,7 @@ type Deps struct {
 	AccountService  AccountService
 	DirectorService DirectorService
 	MovieService    MovieService
-	ListsService    ListsService
+	ListService     ListsService
 }
 
 type Handler struct {
@@ -47,7 +47,7 @@ func NewHandler(deps Deps, logger *logger.Logger) Handler {
 		Account:  NewAccountHandler(deps.AccountService, logger),
 		Director: NewDirectorHandler(deps.DirectorService, logger),
 		Movie:    NewMovieHandler(deps.MovieService, logger),
-		List:     NewListHandler(deps.ListsService),
+		List:     NewListHandler(deps.ListService, logger),
 		log:      logger,
 	}
 }

--- a/backend/app/transport/rest/handler/list.go
+++ b/backend/app/transport/rest/handler/list.go
@@ -32,7 +32,7 @@ func (h *ListHandler) create(c *gin.Context) {
 		return
 	}
 
-	ID, ok := c.Get(userCtx)
+	ctxAccountID, ok := c.Get(userCtx)
 	if !ok {
 		h.logger.Debugw("get from contex: %w", core.ErrContexAccountNotFound)
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": core.ErrContexAccountNotFound.Error()})
@@ -40,7 +40,7 @@ func (h *ListHandler) create(c *gin.Context) {
 		return
 	}
 
-	accountID, err := uuid.Parse(ID.(string))
+	accountID, err := uuid.Parse(ctxAccountID.(string))
 	if err != nil {
 		h.logger.Debugw("uuid parse error: %w", err)
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/backend/app/transport/rest/handler/list.go
+++ b/backend/app/transport/rest/handler/list.go
@@ -1,21 +1,68 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 
+	"github.com/Brigant/PetPorject/backend/app/core"
+	"github.com/Brigant/PetPorject/backend/logger"
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 )
 
 type ListHandler struct {
 	service ListsService
+	logger  *logger.Logger
 }
 
-func NewListHandler(s ListsService) ListHandler {
-	return ListHandler{service: s}
+func NewListHandler(s ListsService, log *logger.Logger) ListHandler {
+	return ListHandler{
+		service: s,
+		logger:  log,
+	}
 }
 
 func (h *ListHandler) create(c *gin.Context) {
-	c.JSON(http.StatusCreated, gin.H{"create": "res"})
+	var list core.MovieList
+
+	if err := c.ShouldBindJSON(&list); err != nil {
+		h.logger.Debugw("bind json error: %w", err)
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+
+		return
+	}
+
+	ID, ok := c.Get(userCtx)
+	if !ok {
+		h.logger.Debugw("get from contex: %w", core.ErrContexAccountNotFound)
+	}
+
+	accountID, err := uuid.Parse(ID.(string))
+	if err != nil {
+		h.logger.Debugw("uuid parse error: %w", err)
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+
+		return
+	}
+
+	list.AccountID = accountID
+
+	listID, err := h.service.Create(list)
+	if err != nil {
+		if errors.Is(err, core.ErrDuplicateRow) {
+			h.logger.Debugw("service create got an error: %w", err)
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+
+			return
+		}
+
+		h.logger.Debugw("service create got an error: %w", err)
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{"created with ID": listID})
 }
 
 func (h *ListHandler) get(c *gin.Context) {

--- a/backend/app/transport/rest/handler/list.go
+++ b/backend/app/transport/rest/handler/list.go
@@ -35,6 +35,9 @@ func (h *ListHandler) create(c *gin.Context) {
 	ID, ok := c.Get(userCtx)
 	if !ok {
 		h.logger.Debugw("get from contex: %w", core.ErrContexAccountNotFound)
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": core.ErrContexAccountNotFound.Error()})
+
+		return
 	}
 
 	accountID, err := uuid.Parse(ID.(string))
@@ -46,6 +49,13 @@ func (h *ListHandler) create(c *gin.Context) {
 	}
 
 	list.AccountID = accountID
+
+	if err := list.Validate(); err != nil {
+		h.logger.Debugw("list validation: %w", err)
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+
+		return
+	}
 
 	listID, err := h.service.Create(list)
 	if err != nil {

--- a/backend/app/transport/rest/handler/list_test.go
+++ b/backend/app/transport/rest/handler/list_test.go
@@ -1,0 +1,99 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Brigant/PetPorject/backend/logger"
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestList_create(t *testing.T) {
+	log, err := logger.New("DEBUG")
+	if err != nil {
+		t.FailNow()
+	}
+
+	type mockBehavior func(s *MockListsService)
+
+	testCasesTable := map[string]struct {
+		inputBody            string
+		accountID            string
+		userCtx              string
+		mockBehavior         mockBehavior
+		expectedStatusCode   int
+		expectedResponseBody string
+	}{
+		"Successful case": {
+			inputBody: `{"type":"favorite","movie_id":"6b823d5e-3d37-4617-a568-226e2e31a4f4"}`,
+			accountID: "8c172d76-f750-4369-a5e2-27c877299168",
+			userCtx:   userCtx,
+			mockBehavior: func(s *MockListsService) {
+				s.EXPECT().Create(gomock.Any()).Return("8c172d76-f750-4369-a5e2-27c877299168", nil).Times(1)
+			},
+			expectedStatusCode:   http.StatusCreated,
+			expectedResponseBody: `{"created with ID":"8c172d76-f750-4369-a5e2-27c877299168"}`,
+		},
+		"Wrong context": {
+			inputBody:            `{"type":"favorite","movie_id":"6b823d5e-3d37-4617-a568-226e2e31a4f4"}`,
+			accountID:            "8c172d76-f750-4369-a5e2-27c877299168",
+			userCtx:              "wrong",
+			mockBehavior:         func(s *MockListsService) {},
+			expectedStatusCode:   http.StatusBadRequest,
+			expectedResponseBody: `{"error":"no account found in contex"}`,
+		},
+		"Wrong accountID context": {
+			inputBody:            `{"type":"favorite","movie_id":"6b823d5e-3d37-4617-a568-226e2e31a4f4"}`,
+			accountID:            "",
+			userCtx:              userCtx,
+			mockBehavior:         func(s *MockListsService) {},
+			expectedStatusCode:   http.StatusBadRequest,
+			expectedResponseBody: `{"error":"invalid UUID length: 0"}`,
+		},
+		"Bad type": {
+			inputBody:            `{"movie_id":"6b823d5e-3d37-4617-a568-226e2e31a4f4"}`,
+			accountID:            "8c172d76-f750-4369-a5e2-27c877299168",
+			userCtx:              userCtx,
+			mockBehavior:         func(s *MockListsService) {},
+			expectedStatusCode:   http.StatusBadRequest,
+			expectedResponseBody: `{"error":"the movie list type should't be empty"}`,
+		},
+		"Bad movieID": {
+			inputBody:            `{"type":"favorite"}`,
+			accountID:            "8c172d76-f750-4369-a5e2-27c877299168",
+			userCtx:              userCtx,
+			mockBehavior:         func(s *MockListsService) {},
+			expectedStatusCode:   http.StatusBadRequest,
+			expectedResponseBody: `{"error":"the movie ID should't be empty"}`,
+		},
+	}
+
+	for name, testCase := range testCasesTable {
+		t.Run(name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			listService := NewMockListsService(ctrl)
+			testCase.mockBehavior(listService)
+
+			lh := NewListHandler(listService, log)
+
+			response := httptest.NewRecorder()
+			ctx, router := gin.CreateTestContext(response)
+			router.POST("/list", lh.create)
+			ctx.Request = httptest.NewRequest(http.MethodPost, "/list", strings.NewReader(testCase.inputBody))
+
+			ctx.Set(testCase.userCtx, testCase.accountID)
+			lh.create(ctx)
+
+			assert.Equal(t, testCase.expectedStatusCode, response.Code)
+			assert.Equal(t, testCase.expectedResponseBody, response.Body.String())
+		})
+	}
+}

--- a/backend/app/transport/rest/server.go
+++ b/backend/app/transport/rest/server.go
@@ -52,6 +52,7 @@ func SetupAndRun() error {
 			AccountStorage:  storage.AccountDB,
 			DirectorStorage: storage.DirectorDB,
 			MovieStorage:    storage.MovieDB,
+			ListSorage:      storage.ListDB,
 		})
 
 	restHandlers := handler.NewHandler(
@@ -59,6 +60,7 @@ func SetupAndRun() error {
 			DirectorService: services.Director,
 			AccountService:  services.Account,
 			MovieService:    services.Movie,
+			ListService:     services.List,
 		}, logger)
 
 	routes := restHandlers.InitRouter(cfg.Server.Mode)

--- a/backend/migrations/4_create_list_table.down.sql
+++ b/backend/migrations/4_create_list_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "list"

--- a/backend/migrations/4_create_list_table.up.sql
+++ b/backend/migrations/4_create_list_table.up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "list" (
+    "id" uuid DEFAULT gen_random_uuid() NOT NULL,
+    "movie_id" uuid NOT NULL,
+    "account_id" uuid NOT NULL,
+    "type" VARCHAR(255) NOT NULL,
+    "created" Timestamp With Time Zone NOT NULL DEFAULT NOW(),
+    "modified" Timestamp With Time Zone,
+    PRIMARY KEY ("id"),
+    CONSTRAINT "unique_list_id" UNIQUE("id"),
+    CONSTRAINT "unique_account_id_type" UNIQUE("account_id", "type"),
+    CONSTRAINT "movie_fk" FOREIGN KEY (movie_id) REFERENCES public."movie"(id),
+    CONSTRAINT "account_fk" FOREIGN KEY (account_id) REFERENCES public."account"(id)
+);
+
+CREATE TRIGGER update_list_modtime 
+BEFORE UPDATE ON "list" 
+FOR EACH ROW EXECUTE PROCEDURE  update_modified_column();

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/gin-gonic/gin v1.9.0
 	github.com/go-playground/validator/v10 v10.11.2
+	github.com/gocarina/gocsv v0.0.0-20230406101422-6445c2b15027
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.1.2
@@ -23,7 +24,6 @@ require (
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/gocarina/gocsv v0.0.0-20230406101422-6445c2b15027 // indirect
 	github.com/goccy/go-json v0.10.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect


### PR DESCRIPTION
### What needs to be done

The endpoint should be created, which will implement the functionality of creating the favorite movie list and the wish movie list.

---

### Why it needs to be done

The accout must have the possibility to save favorite and wish lists from the whole database.

---

### Acceptance criteria

The client side uses the POST method to the path `/list` and provides the json with the list type, movieID, and accountID

The list should stored only with authenticated account.